### PR TITLE
Add OEA keyboard layout systemwise

### DIFF
--- a/roles/oea/defaults/main.yml
+++ b/roles/oea/defaults/main.yml
@@ -1,0 +1,1 @@
+xkb_path: /usr/share/X11/xkb

--- a/roles/oea/defaults/main.yml
+++ b/roles/oea/defaults/main.yml
@@ -1,1 +1,2 @@
 xkb_path: /usr/share/X11/xkb
+layout_name: oea

--- a/roles/oea/files/oea
+++ b/roles/oea/files/oea
@@ -1,0 +1,54 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+// Generated keyboard layout file with the Keyboard Layout Editor.
+// For more about the software, see http://code.google.com/p/keyboardlayouteditor
+//
+
+xkb_symbols "oea-us"
+{
+	name[Group1] = "OEA layout for US keyboard";
+
+	include "us(basic)"
+
+	key <AB01> { [          comma,           less                                 ] }; // , < 
+	key <AB02> { [         period,        greater                                 ] }; // . > 
+	key <AB03> { [              v,              V                                 ] }; // v V 
+	key <AB04> { [              y,              Y                                 ] }; // y Y 
+	key <AB05> { [              k,              K                                 ] }; // k K 
+	key <AB06> { [              d,              D                                 ] }; // d D 
+	key <AB07> { [              c,              C                                 ] }; // c C 
+	key <AB08> { [              l,              L                                 ] }; // l L 
+	key <AB09> { [              b,              B                                 ] }; // b B 
+	key <AB10> { [          slash,       question                                 ] }; // / ? 
+
+	key <AC01> { [              o,              O                                 ] }; // o O 
+	key <AC02> { [              e,              E                                 ] }; // e E 
+	key <AC03> { [              a,              A                                 ] }; // a A 
+	key <AC04> { [              i,              I                                 ] }; // i I 
+	key <AC05> { [              u,              U                                 ] }; // u U 
+	key <AC06> { [              g,              G                                 ] }; // g G 
+	key <AC07> { [              h,              H                                 ] }; // h H 
+	key <AC08> { [              t,              T                                 ] }; // t T 
+	key <AC09> { [              s,              S                                 ] }; // s S 
+	key <AC10> { [              n,              N                                 ] }; // n N 
+	key <AC11> { [     apostrophe,       quotedbl                                 ] }; // ' " 
+
+	key <AD01> { [              x,              X                                 ] }; // x X 
+	key <AD02> { [          minus,     underscore                                 ] }; // - _ 
+	key <AD03> { [              q,              Q                                 ] }; // q Q 
+	key <AD04> { [      semicolon,          colon                                 ] }; // ; : 
+	key <AD05> { [              f,              F                                 ] }; // f F 
+	key <AD06> { [              j,              J                                 ] }; // j J 
+	key <AD07> { [              m,              M                                 ] }; // m M 
+	key <AD08> { [              r,              R                                 ] }; // r R 
+	key <AD09> { [              w,              W                                 ] }; // w W 
+	key <AD10> { [              p,              P                                 ] }; // p P 
+	key <AD11> { [              z,              Z                                 ] }; // z Z 
+	key <AD12> { [    bracketleft,      braceleft                                 ] }; // [ { 
+
+	key <AE11> { [          equal,           plus                                 ] }; // = + 
+	key <AE12> { [      backslash,            bar                                 ] }; // \ | 
+
+	key <BKSL> { [   bracketright,     braceright                                 ] }; // ] } 
+};
+

--- a/roles/oea/files/oea
+++ b/roles/oea/files/oea
@@ -19,7 +19,6 @@ xkb_symbols "oea-us"
 	key <AB07> { [              c,              C                                 ] }; // c C 
 	key <AB08> { [              l,              L                                 ] }; // l L 
 	key <AB09> { [              b,              B                                 ] }; // b B 
-	key <AB10> { [          slash,       question                                 ] }; // / ? 
 
 	key <AC01> { [              o,              O                                 ] }; // o O 
 	key <AC02> { [              e,              E                                 ] }; // e E 
@@ -31,7 +30,6 @@ xkb_symbols "oea-us"
 	key <AC08> { [              t,              T                                 ] }; // t T 
 	key <AC09> { [              s,              S                                 ] }; // s S 
 	key <AC10> { [              n,              N                                 ] }; // n N 
-	key <AC11> { [     apostrophe,       quotedbl                                 ] }; // ' " 
 
 	key <AD01> { [              x,              X                                 ] }; // x X 
 	key <AD02> { [          minus,     underscore                                 ] }; // - _ 
@@ -50,5 +48,7 @@ xkb_symbols "oea-us"
 	key <AE12> { [      backslash,            bar                                 ] }; // \ | 
 
 	key <BKSL> { [   bracketright,     braceright                                 ] }; // ] } 
+
+	key <INS> { [ ISO_Group_Latch ] };
 };
 

--- a/roles/oea/files/oea.xml
+++ b/roles/oea/files/oea.xml
@@ -1,0 +1,19 @@
+<layout>
+    <configItem>
+        <name>oea</name>
+        <shortDescription>en</shortDescription>
+        <description>OEA layout</description>
+        <languageList>
+            <iso639Id>eng</iso639Id>
+            <iso639Id>jpn</iso639Id>
+        </languageList>
+    </configItem>
+    <variantList>
+        <variant>
+            <configItem>
+                <name>oea-us</name>
+                <description>OEA layout for US keyboard</description>
+            </configItem>
+        </variant>
+    </variantList>
+</layout>

--- a/roles/oea/tasks/main.yml
+++ b/roles/oea/tasks/main.yml
@@ -1,7 +1,7 @@
-- name: set keymap file
+- name: set {{ layout_name }} keymap file
   copy:
-    src: oea
-    dest: "{{ xkb_path }}/symbols/oea"
+    src: "{{ layout_name }}"
+    dest: "{{ xkb_path }}/symbols/{{ layout_name }}"
     owner: root
     group: root
     mode: 0644

--- a/roles/oea/tasks/main.yml
+++ b/roles/oea/tasks/main.yml
@@ -6,6 +6,10 @@
     group: root
     mode: 0644
 
+- name: install lib xml of python for xml module
+  package:
+    name: python-lxml
+
 - name: check {{ layout_name }} layout in list
   xml:
     path: "{{ xkb_path }}/rules/evdev.xml"

--- a/roles/oea/tasks/main.yml
+++ b/roles/oea/tasks/main.yml
@@ -5,3 +5,21 @@
     owner: root
     group: root
     mode: 0644
+
+- name: check {{ layout_name }} layout in list
+  xml:
+    path: "{{ xkb_path }}/rules/evdev.xml"
+    xpath: "//layoutList/layout/configItem/name[text()='{{ layout_name }}']"
+    count: yes
+  register: layout
+
+- name: add {{ layout_name }} keymap in list
+  xml:
+    path: "{{ xkb_path }}/rules/evdev.xml"
+    xpath: //layoutList
+    input_type: xml
+    add_children:
+      - "{{ lookup('file', 'oea.xml') }}"
+    pretty_print: yes
+    backup: yes
+  when: layout.count == 0

--- a/roles/oea/tasks/main.yml
+++ b/roles/oea/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: set keymap file
+  copy:
+    src: oea
+    dest: "{{ xkb_path }}/symbols/oea"
+    owner: root
+    group: root
+    mode: 0644

--- a/site.yml
+++ b/site.yml
@@ -14,6 +14,11 @@
       tags:
         - system
 
+    - role: oea
+      become: yes
+      tags:
+        - system
+
     - role: ubuntu/gnome
       tags:
         - user


### PR DESCRIPTION
# OEA配列追加
in evdev

## Ref
- https://wiki.archlinux.jp/index.php/Xorg_でのキーボード設定
- https://qiita.com/uchan_nos/items/a2485b51f5f3fb0db8f8
- http://blog.cnu.jp/2014/05/12/use-xkb/
- http://jou4.hateblo.jp/entry/2015/04/04/191437
- https://askubuntu.com/questions/834650/remap-a-key-combination-to-another-combination-e-g-superctrlshiftj-ctrl